### PR TITLE
Update solution file to trigger opening with Visual Studio 2015 by default

### DIFF
--- a/src/Cake.Slack.sln
+++ b/src/Cake.Slack.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.31101.0
+# Visual Studio 14
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Cake.Slack", "Cake.Slack\Cake.Slack.csproj", "{501A58C8-962C-4140-A4A6-34B7AA22B188}"
 EndProject


### PR DESCRIPTION
Looks like there's some C# 6 syntax in this solution, so building with VS 2013 will fail.