### PR TITLE
Add support for attachment "mrkdwn_in" property

### DIFF
--- a/src/Cake.Slack/Chat/SlackChatMessageAttachment.cs
+++ b/src/Cake.Slack/Chat/SlackChatMessageAttachment.cs
@@ -117,5 +117,13 @@ namespace Cake.Slack.Chat
         /// The fields.
         /// </value>
         public IList<SlackChatMessageAttachmentField> Fields { get; set; }
+
+        /// <summary>
+        /// Collection of fields that use Slack's Markdown-like message formatting. Valid values are "pretext", "text", and "fields".
+        /// </summary>
+        /// <value>
+        /// Which fields use Slack's Markdown-like message formatting.
+        /// </value>
+        public IList<string> Mrkdwn_In { get; set; }
     }
 }


### PR DESCRIPTION
> By default, bot message text will be formatted, but attachments are not.
> To enable formatting on attachment fields, set the mrkdwn_in array on each
> attachment to the list of fields to process.
> Valid values for mrkdwn_in are: ["pretext", "text", "fields"]. Setting
> "fields" will enable markup formatting for the value of each field.

https://api.slack.com/docs/message-formatting#message_formatting

I had originally gone the route of adding an `enum` for the valid values and making the `Mrkdwn_In` property an `IList<>` of that enum, but the JsonWriter serializes enums as their integer values.
